### PR TITLE
Blockquotes

### DIFF
--- a/src/parser/Parser.java
+++ b/src/parser/Parser.java
@@ -9,6 +9,7 @@ import util.StringUtil;
 public class Parser {
 
 	private static final String CODE_BLOCK_DELIMITER = "```";
+	private static final Character BLOCKQUOTE_CHARACTER = '>';
 	
 	public static void toHtml(Reader in, Writer out) throws IOException {
 		
@@ -29,6 +30,8 @@ public class Parser {
 					parseHeading(in, out, line);
 				else if (isCodeBlock(line))
 					parseCodeBlock(in, out, line);
+				else if (isBlockquote(line))
+					parseBlockquote(in, out, line);
 			}
 			else
 			{
@@ -37,7 +40,7 @@ public class Parser {
 			}
 		}
 	}
-	
+
 	private static boolean isHeading(String line) {
 		return line.startsWith("#") 
 			&& StringUtil.countHeadingChars(line, '#') <= 6;
@@ -69,6 +72,37 @@ public class Parser {
 		String preamble = language.isEmpty() ? "" : " class=\"lang-" + language + "\"";
 		
 		out.write("<pre><code" + preamble + ">\n"+ code + "</code></pre>\n");
+	}
+	
+	
+	
+	private static boolean isBlockquote(String line) {
+		return line.startsWith(BLOCKQUOTE_CHARACTER + "");
+	}
+	
+	private static void parseBlockquote(Reader in, Writer out, String firstLine) throws IOException {
+		
+		int prevLevel = 0;
+		int level;
+		String line = firstLine;
+		
+		while ((line = StringUtil.readLine(in)) != null 
+				&& !line.equals(CODE_BLOCK_DELIMITER))
+		{
+			level = StringUtil.countHeadingChars(firstLine, BLOCKQUOTE_CHARACTER);
+			
+			if (level > prevLevel) 
+				for (int i = 0; i + prevLevel < level; i++)
+					out.write("<blockquote>\n");
+			
+			out.write(firstLine.substring(level).trim() + "\n");
+			
+			if (level < prevLevel)
+				for (int i = 0; i + level < prevLevel; i++)
+					out.write("</blockquote>\n");
+			
+			prevLevel = level;
+		}
 	}
 	
 }

--- a/test/conversion/Blockquotes.java
+++ b/test/conversion/Blockquotes.java
@@ -1,0 +1,144 @@
+package conversion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+public class Blockquotes {
+
+	@Test
+	public void simpleBlockquote() throws IOException {
+		String markdown = """
+				```
+				> this is a blockquote
+				```
+				""";
+		
+		String html = """
+				<blockquote>
+				this is a blockquote
+				</blockquote>
+				""";
+		
+		String actual = ConversionTestUtil.parse(markdown);
+		
+		assertEquals(html, actual);
+	}
+	
+	@Test
+	public void multilineBlockquote() throws IOException {
+		String markdown = """
+				```
+				> this is 
+				> a multiline blockquote
+				```
+				""";
+		
+		String html = """
+				<blockquote>
+				this is
+				a multiline blockquote
+				</blockquote>
+				""";
+		
+		String actual = ConversionTestUtil.parse(markdown);
+		
+		assertEquals(html, actual);
+	}
+	
+	@Test
+	public void multipleBlockquote() throws IOException {
+		String markdown = """
+				```
+				> this is a blockquote
+				
+				> this is another blockquote
+				
+				> and another blockquote!
+				```
+				""";
+		
+		String html = """
+				<blockquote>
+				this is a blockquote
+				</blockquote>
+				<blockquote>
+				this is another blockquote
+				</blockquote>
+				<blockquote>
+				and another blockquote!
+				</blockquote>
+				""";
+		
+		String actual = ConversionTestUtil.parse(markdown);
+		
+		assertEquals(html, actual);
+	}
+	
+	@Test
+	public void nestedBlockquote() throws IOException {
+		String markdown = """
+				```
+				> outside
+				>> nested
+				```
+				""";
+		
+		String html = """
+				<blockquote>
+				outside
+				<blockquote>
+				nested
+				</blockquote>
+				</blockquote>
+				""";
+		
+		String actual = ConversionTestUtil.parse(markdown);
+		
+		assertEquals(html, actual);
+	}
+	
+	@Test
+	public void multipleNestedBlockquotes() throws IOException {
+		String markdown = """
+				```
+				> outside
+				>> nested
+				> out
+				>> nested
+				>>> nested again
+				> out
+				>>> double nested
+				```
+				""";
+		
+		String html = """
+				<blockquote>
+				outside
+				<blockquote>
+				nested
+				</blockquote>
+				out
+				<blockquote>
+				nested
+				<blockquote>
+				nested again
+				</blockquote>
+				</blockquote>
+				out
+				</blockquote>
+				</blockquote>
+				double nested
+				</blockquote>
+				</blockquote>
+				</blockquote>
+				""";
+		
+		String actual = ConversionTestUtil.parse(markdown);
+		
+		assertEquals(html, actual);
+	}
+	
+}


### PR DESCRIPTION
Implemented blockquotes from issue #4 

These work a little different from how other parsers implement.
This implementation always puts the blockquote in the respective nesting level, while other implementations only increment nesting levels and close them all in the end.